### PR TITLE
fix(steamcmd): handle having no beta key

### DIFF
--- a/scripts/update-resonite.sh
+++ b/scripts/update-resonite.sh
@@ -10,7 +10,14 @@ fi
 
 HEADLESS_DIRECTORY="/home/container/Headless"
 
-/home/container/steamcmd/steamcmd.sh +login ${STEAM_USER} ${STEAM_PASS} +force_install_dir /home/container +app_license_request 2519830 +app_update 2519830 -beta ${STEAM_BRANCH} -betapassword ${BETA_CODE} validate +quit
+STEAMCMD_BETA_PASSWORD=""
+
+if [ ! "${BETA_CODE}" = "" ]; then
+  STEAMCMD_BETA_PASSWORD="-betapassword ${BETA_CODE}"
+fi
+
+
+/home/container/steamcmd/steamcmd.sh +login ${STEAM_USER} ${STEAM_PASS} +force_install_dir /home/container +app_license_request 2519830 +app_update 2519830 -beta ${STEAM_BRANCH} ${STEAMCMD_BETA_PASSWORD} validate +quit
 
 #Mod installation if ENABLE_MODS is true. Heavily inspired and pulled from work by Spex. Thank you
 if [ "${ENABLE_MODS}" = "true" ]; then


### PR DESCRIPTION
This adds the ability to use a Steam branch where a beta key is not supplied.

Closes https://github.com/voxelbonecloud/resonite-headless-docker/issues/31

