### PR TITLE
Update to Debian 13 "trixie"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN	apt update \
 	&& dpkg --add-architecture i386 \
 	&& apt update \
 	&& apt install git lib32gcc-s1 libfreetype6 dotnet-runtime-9.0 -y \
+	&& rm -r /var/lib/apt/lists/* \
 	&& groupadd -g 1000 container \
 	&& useradd -u 1000 -g 1000 -m -d /home/container -s /bin/bash container
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM	debian:trixie-slim
 
 LABEL	author="Voxel Bone Cloud" maintainer="github@voxelbone.cloud"
-LABEL org.opencontainers.image.source=https://github.com/voxelbonecloud/resonite-headless-docker
-LABEL org.opencontainers.image.description="Docker image based on Debian trixie Slim image with .NET 9 for hosting Resonite Headless servers. Supports automatic modding of the Headless."
-LABEL org.opencontainers.image.licenses=MIT-0
-LABEL org.opencontainers.image.authors="Voxel Bone Cloud"
+LABEL	org.opencontainers.image.source=https://github.com/voxelbonecloud/resonite-headless-docker
+LABEL	org.opencontainers.image.description="Docker image based on Debian trixie Slim image with .NET 9 for hosting Resonite Headless servers. Supports automatic modding of the Headless."
+LABEL	org.opencontainers.image.licenses=MIT-0
+LABEL	org.opencontainers.image.authors="Voxel Bone Cloud"
 
 RUN	apt update \
 	&& apt install curl -y \
@@ -25,8 +25,8 @@ RUN	chmod +x /scripts/*
 RUN	mkdir /Logs \
 	&& chown -R container:container /Logs
 
-RUN mkdir /Config \
-    && chown -R container:container /Config
+RUN	mkdir /Config \
+	&& chown -R container:container /Config
 
 RUN	mkdir -p /RML /RML/rml_mods /RML/rml_libs /RML/rml_config \
 	&& chown -R container:container /RML

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ RUN	apt update \
 	&& rm /tmp/packages-microsoft-prod.deb \
 	&& dpkg --add-architecture i386 \
 	&& apt update \
-	&& apt search dotnet \ 
-	&& apt install curl git lib32gcc-s1 libfreetype6 dotnet-runtime-9.0 -y \
+	&& apt install git lib32gcc-s1 libfreetype6 dotnet-runtime-9.0 -y \
 	&& groupadd -g 1000 container \
 	&& useradd -u 1000 -g 1000 -m -d /home/container -s /bin/bash container
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,20 @@
-FROM	mcr.microsoft.com/dotnet/runtime:9.0-bookworm-slim
+FROM	debian:trixie-slim
 
 LABEL	author="Voxel Bone Cloud" maintainer="github@voxelbone.cloud"
 LABEL org.opencontainers.image.source=https://github.com/voxelbonecloud/resonite-headless-docker
-LABEL org.opencontainers.image.description="Docker image based on Debian Bookworm Slim image with dotnet8 for hosting Resonite Headless servers. Supports automatic modding of the Headless."
+LABEL org.opencontainers.image.description="Docker image based on Debian trixie Slim image with .NET 9 for hosting Resonite Headless servers. Supports automatic modding of the Headless."
 LABEL org.opencontainers.image.licenses=MIT-0
 LABEL org.opencontainers.image.authors="Voxel Bone Cloud"
 
 RUN	apt update \
+	&& apt install curl -y \
+	&& curl https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -o /tmp/packages-microsoft-prod.deb \
+	&& dpkg -i /tmp/packages-microsoft-prod.deb \
+	&& rm /tmp/packages-microsoft-prod.deb \
 	&& dpkg --add-architecture i386 \
-	&& apt install curl git lib32gcc-s1 libfreetype6 -y \
+	&& apt update \
+	&& apt search dotnet \ 
+	&& apt install curl git lib32gcc-s1 libfreetype6 dotnet-runtime-9.0 -y \
 	&& groupadd -g 1000 container \
 	&& useradd -u 1000 -g 1000 -m -d /home/container -s /bin/bash container
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Resonite Headless 
 
-Docker image based on Debian Bookworm Slim image with dotnet9 for hosting Resonite Headless servers. Supports automatic modding of the Headless and updating config and mod files from git repos.
+Docker image based on Debian trixie with .NET 9 for hosting Resonite Headless servers. Supports automatic modding of the Headless and updating config and mod files from git repos.
 
 You can find examples for Portainer deployments in the [Portainer folder](portainer/)
 


### PR DESCRIPTION
This updates the headless image to be based off Debian 13 "trixie".

As Microsoft are no longer publishing Debian based container images for .NET runtime, we are switching to installing .NET runtime on top of a stock Debian slim image instead of basing off an image published by Microsoft.