### PR TITLE
Remove daily build trigger

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,8 +2,6 @@ name: Docker
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '24 1 * * 1'
   push:
     branches: [ "main" ]
     paths:


### PR DESCRIPTION
There is no need to build this image on a schedule. We can just rely on the "on push to main" trigger. This is especially true since the Resonite code isn't hosted inside the image anyhow, meaning Resonite updates on container restart, not new image creation.